### PR TITLE
Remove GitHub sponsorship iframe from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,8 +125,6 @@ title: Home
 				kofiwidget2.init('Support me on Ko-fi', '#f6c915', 'B0B01DEZHE');
 				kofiwidget2.draw();
 			</script>
-			&nbsp&nbsp&nbsp&nbsp<iframe src="https://github.com/sponsors/solomonrajan/button" title="Sponsor solomonrajan" height="32"
-				width="114" style="border: 0; border-radius: 6px;"></iframe>
 		</div>
 	</div>
 </div>

--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@ title: Home
 				kofiwidget2.init('Support me on Ko-fi', '#f6c915', 'B0B01DEZHE');
 				kofiwidget2.draw();
 			</script>
-			&nbsp&nbsp&nbsp<iframe src="https://github.com/sponsors/solomonrajan/button" title="Sponsor solomonrajan" height="32"
+			&nbsp&nbsp&nbsp&nbsp<iframe src="https://github.com/sponsors/solomonrajan/button" title="Sponsor solomonrajan" height="32"
 				width="114" style="border: 0; border-radius: 6px;"></iframe>
 		</div>
 	</div>


### PR DESCRIPTION
Eliminate the sponsorship iframe from the index.html file to streamline the page.