### PR TITLE
Remove GitHub stars badge from navbar in blank.html

### DIFF
--- a/_layouts/blank.html
+++ b/_layouts/blank.html
@@ -29,8 +29,6 @@
 		<div class="container">
 			<div class="navbar-translate">
 				<a class="navbar-brand" href="{{ site.baseurl }}/">Nothing Index</a>
-				<img alt="GitHub Repo stars"
-					src="https://img.shields.io/github/stars/Nothing-Index/nothing-index.github.io?style=social">
 				<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
 					aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
 					<span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
Eliminate the GitHub stars badge from the navbar in the blank.html file.